### PR TITLE
Added wrapper for mid function returns

### DIFF
--- a/ljd/ast/builder.py
+++ b/ljd/ast/builder.py
@@ -679,6 +679,8 @@ def _build_return(state, addr, instruction):
 
     base = instruction.A
     last_slot = base + instruction.CD - 1
+    
+    node.mid_block = addr != state.block.last_address
 
     if instruction.opcode != ins.RETM.opcode:
         last_slot -= 1

--- a/ljd/ast/builder.py
+++ b/ljd/ast/builder.py
@@ -35,6 +35,9 @@ def _build_function_definition(prototype, header):
 
     state = _State()
 
+    setattr(node, "_first_line", prototype.first_line_number)
+    setattr(node, "_last_line", prototype.first_line_number + prototype.lines_count)
+
     state.constants = prototype.constants
     state.debuginfo = prototype.debuginfo
     state.header = header
@@ -185,12 +188,18 @@ def _blockenize(state, instructions):
         block.first_address = previous_last_address + 1
         block.last_address = last_address
 
+        setattr(block, "_first_line", state.debuginfo.lookup_line_number(block.first_address))
+        setattr(block, "_last_line", state.debuginfo.lookup_line_number(block.last_address))
+
         state.blocks.append(block)
         state.block_starts[block.first_address] = block
 
         previous_last_address = last_address
 
         index += 1
+    
+    state.blocks[-1]._first_line += 1
+    state.blocks[-1]._last_line += 1
 
 
 def _establish_warps(state, instructions):

--- a/ljd/ast/mutator.py
+++ b/ljd/ast/mutator.py
@@ -288,6 +288,7 @@ class MutatorVisitor(traverse.Visitor):
             return
 
         elseif = nodes.ElseIf()
+        setattr(elseif, "_first_line", subif._first_line)
         if hasattr(subif, "_decompilation_error_here"):
             setattr(elseif, "_decompilation_error_here", True)
         elseif.expression = subif.expression
@@ -349,6 +350,9 @@ class MutatorVisitor(traverse.Visitor):
 
             if has_same_table(src, table):
                 break
+
+            #if has_same_table(dst.key, table):
+            #    break
 
             success = insert_table_record(constructor, dst.key, src, False)
 

--- a/ljd/ast/nodes.py
+++ b/ljd/ast/nodes.py
@@ -575,6 +575,7 @@ class EndWarp:
 class Return:
     def __init__(self):
         self.returns = ExpressionsList()
+        self.mid_block = None
 
     def _accept(self, visitor):
         visitor._visit_node(visitor.visit_return, self)

--- a/ljd/lua/writer.py
+++ b/ljd/lua/writer.py
@@ -863,7 +863,9 @@ class Visitor(traverse.Visitor):
 
     def visit_return(self, node):
         self._start_statement(STATEMENT_RETURN)
-
+        if node.mid_block:
+             self._write("do ")
+        
         if len(node.returns.contents) > 0:
             self._write("return ")
         else:
@@ -871,6 +873,8 @@ class Visitor(traverse.Visitor):
 
         self._visit(node.returns)
 
+        if node.mid_block:
+             self._write(" end")
         self._end_statement(STATEMENT_RETURN)
 
     def visit_break(self, node):

--- a/ljd/rawdump/parser.py
+++ b/ljd/rawdump/parser.py
@@ -18,10 +18,13 @@ class _State:
         self.prototypes = []
 
 
-def parse(filename, on_parse_header=None):
+def parse(file_in, on_parse_header=None, mem=None):
     parser = _State()
 
-    parser.stream.open(filename)
+    if mem:
+        parser.stream.open_memory(file_in, mem)
+    else:
+        parser.stream.open(file_in)
 
     header = ljd.rawdump.header.Header()
 

--- a/ljd/util/binstream.py
+++ b/ljd/util/binstream.py
@@ -21,6 +21,11 @@ class BinStream:
         self.name = filename
         self.fd = io.open(filename, 'rb')
         self.size = os.stat(filename).st_size
+    
+    def open_memory(self, filename, mem):
+        self.name = filename
+        self.fd = io.BytesIO(mem)
+        self.size = len(mem)
 
     def close(self):
         self.fd.close()


### PR DESCRIPTION
Solves decompilaton of 
```lua
function test()
	print("Header")

	do return end

	print("Footer")
end
```
into 
```lua
function test()
	print("Header")

	return --invalid mid function return, won't compile again

	print("Footer")
end
```
This also needs to be done for break statements but it's not a trivial fix as this one